### PR TITLE
Add process for updating NSIS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,3 @@ NSIS/Plugins/x86-unicode/
 !NSIS/Plugins/x86-unicode/nsDialogs.dll
 !NSIS/Plugins/x86-unicode/System.dll
 !NSIS/Plugins/x86-unicode/TypeLib.dll
-

--- a/readme.md
+++ b/readme.md
@@ -15,11 +15,14 @@ a custom installation is created.
 While a custom NSIS installation could be created using the installer,
 to save time a full installation distributed zip is download and extracted.
 Then the contents are filtered by [.gitignore](./.gitignore).
-This creates a functionally similar result as building a custom installation with the installer.
+[.gitignore](./.gitignore) was written to be filter the same contents
+as the NSIS 2.51 custom installation used in older versions of NVDA.
+Additionally, unused exes are also filtered to minimize disk space usage.
 
 **Updating NSIS**
 
 These steps use the root directory of this git submodule as the working directory.
+When developing from the NVDA repository, the working directory for updating NSIS is `include/nsis`.
 
 1. Remove the folder `./NSIS`.
 1. Download the latest `.zip` distribution from [the NSIS sourceforge](https://sourceforge.net/projects/nsis/files/).
@@ -29,7 +32,12 @@ These steps use the root directory of this git submodule as the working director
     - Perform `git add NSIS` to track new files.
     - Update `.gitignore` if necessary.
       - Perform `git diff --stat NSIS`, ensure no unexpected files are being added.
-      - Check `git clean -xdn NSIS`, ensure no unexpected files are being ignored.
+        - Expected new files may include:
+          - graphics
+          - languages
+      - Check `git clean -xdn NSIS`, ensure no unexpected files are being ignored by .gitignore.
+        - This is unlikely unless NVDA requires new features bundled with NSIS.
+        - If building the launcher fails, consider updating .gitignore.
     - Perform `git clean -xdf NSIS`, as fresh clones need to be able to work without ignored files.
 1. From a command prompt at the NVDA repository root, build the launcher:
     - `scons launcher`


### PR DESCRIPTION
Includes a `.gitignore` file, this is used for selecting which parts of the NSIS installed distribution is needed as a dependency for NVDA.

A readme has been added for updating and testing NSIS.